### PR TITLE
Estimate small area land uses

### DIFF
--- a/urban_atlas/download.py
+++ b/urban_atlas/download.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Any
+
+import fs
+from fs.tools import copy_file_data
+
+
+def fetch_s3_file(product: str, bucket: str) -> None:
+    filepath = Path(product)
+    filename = filepath.name
+    if not filepath.exists():
+        s3fs = fs.open_fs(bucket)
+        with s3fs.open(filename, "rb") as remote_file:
+            with open(filepath, "wb") as local_file:
+                copy_file_data(remote_file, local_file)

--- a/urban_atlas/environment.yaml
+++ b/urban_atlas/environment.yaml
@@ -1,0 +1,6 @@
+name: urban_atlas
+channels:
+  - conda-forge
+dependencies:
+  - geopandas
+  - ipykernel

--- a/urban_atlas/group_footprints_by_small_areas.py
+++ b/urban_atlas/group_footprints_by_small_areas.py
@@ -1,0 +1,59 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
+#   kernelspec:
+#     display_name: 'Python 3.9.6 64-bit (''urban-atlas'': conda)'
+#     name: python3
+# ---
+
+# %%
+import geopandas as gpd
+
+# %% tags=["parameters"]
+upstream = {
+    "download_small_areas": "data/external/dublin_small_area_boundaries_in_routing_keys.gpkg",
+    "upload_urban_atlas": "data/raw/Urban Atlas",
+}
+product = {"data": "data/processed/urban_atlas_small_area_item_area.csv.gz"}
+
+# %%
+urban_atlas = gpd.read_file(upstream["upload_urban_atlas"])
+
+# %%
+small_areas = gpd.read_file(upstream["download_small_areas"])
+
+# %%
+urban_atlas_representative_points = (
+    urban_atlas.geometry.representative_point()
+    .to_frame()
+    .rename(columns={0: "geometry"})
+)
+
+# %%
+urban_atlas_in_small_areas = (
+    gpd.sjoin(
+        urban_atlas_representative_points.to_crs(epsg=2157),
+        small_areas.to_crs(epsg=2157),
+        op="within",
+    )
+    .drop(columns="geometry")
+    .join(urban_atlas)
+    .drop(columns="index_right")
+)
+
+# %%
+urban_atlas_small_area_item_area = (
+    urban_atlas_in_small_areas.groupby(["small_area", "ITEM"])
+    .agg({"geometry": lambda x: x.area.sum()})
+    .rename(columns={"geometry": "area_m2"})
+)
+
+# %%
+urban_atlas_small_area_item_area.to_csv(
+    product["data"]["urban_atlas_small_area_item_area"]
+)

--- a/urban_atlas/group_footprints_by_small_areas.py
+++ b/urban_atlas/group_footprints_by_small_areas.py
@@ -12,17 +12,21 @@
 # ---
 
 # %%
+from pathlib import Path
 import geopandas as gpd
 
 # %% tags=["parameters"]
-upstream = {
-    "download_small_areas": "data/external/dublin_small_area_boundaries_in_routing_keys.gpkg",
-    "upload_urban_atlas": "data/raw/Urban Atlas",
-}
-product = {"data": "data/processed/urban_atlas_small_area_item_area.csv.gz"}
+upstream = None
+product = None
+urban_atlas_filepath = None
 
 # %%
-urban_atlas = gpd.read_file(upstream["upload_urban_atlas"])
+assert Path(
+    urban_atlas_filepath
+).exists(), f"Please upload {Path(urban_atlas_filepath).name} to data/raw"
+
+# %%
+urban_atlas = gpd.read_file(urban_atlas_filepath)
 
 # %%
 small_areas = gpd.read_file(upstream["download_small_areas"])
@@ -54,6 +58,4 @@ urban_atlas_small_area_item_area = (
 )
 
 # %%
-urban_atlas_small_area_item_area.to_csv(
-    product["data"]["urban_atlas_small_area_item_area"]
-)
+urban_atlas_small_area_item_area.to_csv(product["data"])

--- a/urban_atlas/pipeline.yaml
+++ b/urban_atlas/pipeline.yaml
@@ -1,0 +1,20 @@
+meta:
+  extract_upstream: False
+
+tasks:
+  - source: download.fetch_s3_file
+    name: download_small_areas
+    params:
+      bucket: codema-dev
+    product: data/external/dublin_small_area_boundaries_in_routing_keys.gpkg
+
+  - source: group_footprints_by_small_areas.py
+    name: group_footprints_by_small_areas
+    params:
+      small_area_filepath: data/external/dublin_small_area_boundaries_in_routing_keys.gpkg
+      urban_atlas_filepath: data/raw/Urban Atlas
+    product:
+      nb: data/notebooks/group_footprints_by_small_areas.ipynb
+      data: data/processed/urban_atlas_small_area_item_area.csv.gz
+    upstream: download_small_areas
+


### PR DESCRIPTION
Link Urban Atlas land uses to Small areas by taking a representative point for each polygon and checking if the small area boundary contains it via geopandas.  Automate the downloading of the small area boundaries from s3 and feed the data into the notebook via a ploomber 