### PR TITLE
Save valuation office facts

### DIFF
--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -35,3 +35,11 @@ tasks:
     params:
       boiler_efficiency: 0.85
     product: data/processed/2021_04_dublin_valuation_office.csv
+  
+  - source: tasks.save_building_columns
+    name: save_electricity_demands
+    params:
+      columns: 
+        - typical_electricity_kwh_per_m2y
+        - electricity_demand_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_electricity_demands.csv

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -91,10 +91,19 @@ tasks:
     product: data/processed/2021_04_dublin_valuation_office_fossil_fuel_heat_demands.csv
 
   - source: tasks.save_building_columns
-    name: save_industrial_heat_demands
+    name: save_industrial_low_temperature_heat_demands
     params:
       columns: 
-        - typical_industrial_heat_kwh_per_m2y
-        - industrial_heat_demand_mwh_per_y
-      filter_on_column: industrial_heat_demand_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_industrial_heat_demands.csv
+        - typical_industrial_low_temperature_heat_kwh_per_m2y
+        - industrial_low_temperature_heat_demand_mwh_per_y
+      filter_on_column: industrial_low_temperature_heat_demand_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_industrial_low_temperature_heat_demands.csv
+  
+  - source: tasks.save_building_columns
+    name: save_industrial_high_temperature_heat_demands
+    params:
+      columns: 
+        - typical_industrial_high_temperature_heat_kwh_per_m2y
+        - industrial_high_temperature_heat_demand_mwh_per_y
+      filter_on_column: industrial_high_temperature_heat_demand_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_industrial_high_temperature_heat_demands.csv

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -73,6 +73,15 @@ tasks:
     product: data/processed/2021_04_dublin_valuation_office_process_energy_demands.csv
   
   - source: tasks.save_building_columns
+    name: save_electricity_heat_demands
+    params:
+      columns: 
+        - typical_electricity_heat_kwh_per_m2y
+        - electricity_heat_demand_mwh_per_y
+      filter_on_column: electricity_heat_demand_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_electricity_heat_demands.csv
+
+  - source: tasks.save_building_columns
     name: save_fossil_fuel_heat_demands
     params:
       columns: 

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -42,6 +42,7 @@ tasks:
       columns: 
         - typical_electricity_kwh_per_m2y
         - electricity_demand_mwh_per_y
+      filter_on_column: electricity_demand_mwh_per_y
     product: data/processed/2021_04_dublin_valuation_office_electricity_demands.csv
 
   - source: tasks.save_building_columns
@@ -50,6 +51,7 @@ tasks:
       columns: 
         - typical_fossil_fuel_kwh_per_m2y
         - fossil_fuel_demand_mwh_per_y
+      filter_on_column: fossil_fuel_demand_mwh_per_y
     product: data/processed/2021_04_dublin_valuation_office_fossil_fuel_demands.csv
 
   - source: tasks.save_building_columns
@@ -58,6 +60,7 @@ tasks:
       columns: 
         - typical_building_energy_kwh_per_m2y
         - building_energy_mwh_per_y
+      filter_on_column: building_energy_mwh_per_y
     product: data/processed/2021_04_dublin_valuation_office_building_energy_demands.csv
 
   - source: tasks.save_building_columns
@@ -66,6 +69,7 @@ tasks:
       columns: 
         - typical_process_energy_kwh_per_m2y
         - process_energy_mwh_per_y
+      filter_on_column: process_energy_mwh_per_y
     product: data/processed/2021_04_dublin_valuation_office_process_energy_demands.csv
   
   - source: tasks.save_building_columns
@@ -74,6 +78,7 @@ tasks:
       columns: 
         - typical_fossil_fuel_heat_kwh_per_m2y
         - fossil_fuel_heat_demand_mwh_per_y
+      filter_on_column: fossil_fuel_heat_demand_mwh_per_y
     product: data/processed/2021_04_dublin_valuation_office_fossil_fuel_heat_demands.csv
 
   - source: tasks.save_building_columns
@@ -82,4 +87,5 @@ tasks:
       columns: 
         - typical_industrial_heat_kwh_per_m2y
         - industrial_heat_demand_mwh_per_y
+      filter_on_column: industrial_heat_demand_mwh_per_y
     product: data/processed/2021_04_dublin_valuation_office_industrial_heat_demands.csv

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -43,3 +43,43 @@ tasks:
         - typical_electricity_kwh_per_m2y
         - electricity_demand_mwh_per_y
     product: data/processed/2021_04_dublin_valuation_office_electricity_demands.csv
+
+  - source: tasks.save_building_columns
+    name: save_fossil_fuel_demands
+    params:
+      columns: 
+        - typical_fossil_fuel_kwh_per_m2y
+        - fossil_fuel_demand_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_fossil_fuel_demands.csv
+
+  - source: tasks.save_building_columns
+    name: save_building_energy_demands
+    params:
+      columns: 
+        - typical_building_energy_kwh_per_m2y
+        - building_energy_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_building_energy_demands.csv
+
+  - source: tasks.save_building_columns
+    name: save_process_energy_demands
+    params:
+      columns: 
+        - typical_process_energy_kwh_per_m2y
+        - process_energy_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_process_energy_demands.csv
+  
+  - source: tasks.save_building_columns
+    name: save_fossil_fuel_heat_demands
+    params:
+      columns: 
+        - typical_fossil_fuel_heat_kwh_per_m2y
+        - fossil_fuel_heat_demand_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_fossil_fuel_heat_demands.csv
+
+  - source: tasks.save_building_columns
+    name: save_industrial_heat_demands
+    params:
+      columns: 
+        - typical_industrial_heat_kwh_per_m2y
+        - industrial_heat_demand_mwh_per_y
+    product: data/processed/2021_04_dublin_valuation_office_industrial_heat_demands.csv

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -199,6 +199,12 @@ def apply_energy_benchmarks_to_floor_areas(
         * kwh_to_mwh
     )
 
+    buildings_with_benchmarks["electricity_heat_demand_mwh_per_y"] = (
+        bounded_area_m2.fillna(0)
+        * buildings_with_benchmarks["typical_electricity_heat_kwh_per_m2y"].fillna(0)
+        * kwh_to_mwh
+        * boiler_efficiency
+    ).fillna(0)
     buildings_with_benchmarks["fossil_fuel_heat_demand_mwh_per_y"] = (
         bounded_area_m2.fillna(0)
         * buildings_with_benchmarks["typical_fossil_fuel_heat_kwh_per_m2y"].fillna(0)

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -190,3 +190,24 @@ def apply_energy_benchmarks_to_floor_areas(
     )
 
     buildings_with_benchmarks.to_csv(product)
+
+
+def save_building_columns(upstream: Any, product: Any, columns: str) -> None:
+    keep_columns = [
+        "PropertyNo",
+        "PropertyNo",
+        "Category",
+        "Use1",
+        "Use2",
+        "List_Status",
+        "X_ITM",
+        "Y_ITM",
+        "Benchmark",
+        "Total_SQM",
+        "bounded_area_m2",
+    ]
+    use_columns = keep_columns + columns
+    buildings = pd.read_csv(
+        upstream["apply_energy_benchmarks_to_floor_areas"], index_col=0
+    ).loc[:, use_columns]
+    buildings.to_csv(product)

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -57,11 +57,14 @@ def weather_adjust_benchmarks(upstream: Any, product: Any) -> None:
     # ASSUMPTION: fossil fuel is only used for space heat & hot water
     fossil_fuel_heat = fossil_fuel * benchmarks["% suitable for DH or HP"]
 
-    industrial_heat = (
+    industrial_low_temperature_heat = (
         benchmarks["Industrial space heat [kWh/m²y]"] * degree_day_factor
         + benchmarks["Industrial process energy [kWh/m²y]"]
         * benchmarks["% suitable for DH or HP"]
     )
+    industrial_high_temperature_heat = benchmarks[
+        "Industrial process energy [kWh/m²y]"
+    ] * (1 - benchmarks["% suitable for DH or HP"])
 
     normalised_benchmarks = pd.DataFrame(
         {
@@ -78,7 +81,8 @@ def weather_adjust_benchmarks(upstream: Any, product: Any) -> None:
             ],
             "typical_electricity_heat_kwh_per_m2y": electricity_heat,
             "typical_fossil_fuel_heat_kwh_per_m2y": fossil_fuel_heat,
-            "typical_industrial_heat_kwh_per_m2y": industrial_heat,
+            "typical_industrial_low_temperature_heat_kwh_per_m2y": industrial_low_temperature_heat,
+            "typical_industrial_high_temperature_heat_kwh_per_m2y": industrial_high_temperature_heat,
         }
     )
 
@@ -211,9 +215,18 @@ def apply_energy_benchmarks_to_floor_areas(
         * kwh_to_mwh
         * boiler_efficiency
     ).fillna(0)
-    buildings_with_benchmarks["industrial_heat_demand_mwh_per_y"] = (
+    buildings_with_benchmarks["industrial_low_temperature_heat_demand_mwh_per_y"] = (
         bounded_area_m2.fillna(0)
-        * buildings_with_benchmarks["typical_industrial_heat_kwh_per_m2y"].fillna(0)
+        * buildings_with_benchmarks[
+            "typical_industrial_low_temperature_heat_kwh_per_m2y"
+        ].fillna(0)
+        * kwh_to_mwh
+    )
+    buildings_with_benchmarks["industrial_high_temperature_heat_demand_mwh_per_y"] = (
+        bounded_area_m2.fillna(0)
+        * buildings_with_benchmarks[
+            "typical_industrial_high_temperature_heat_kwh_per_m2y"
+        ].fillna(0)
         * kwh_to_mwh
     )
 

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -192,7 +192,9 @@ def apply_energy_benchmarks_to_floor_areas(
     buildings_with_benchmarks.to_csv(product)
 
 
-def save_building_columns(upstream: Any, product: Any, columns: str) -> None:
+def save_building_columns(
+    upstream: Any, product: Any, columns: str, filter_on_column: str
+) -> None:
     keep_columns = [
         "PropertyNo",
         "PropertyNo",
@@ -210,4 +212,5 @@ def save_building_columns(upstream: Any, product: Any, columns: str) -> None:
     buildings = pd.read_csv(
         upstream["apply_energy_benchmarks_to_floor_areas"], index_col=0
     ).loc[:, use_columns]
-    buildings.to_csv(product)
+    non_zero_rows = buildings[filter_on_column] > 0
+    buildings[non_zero_rows].to_csv(product, index=False)


### PR DESCRIPTION
Instead of saving the entire contents of the clean valuation office am now save facts.  For example, each electricity_demand_mwh_per_y is saved in its own file alongside the benchmark value and floor area used to create it, and unique identifying information such as the PropertyNo