### PR TITLE
Load valuation office from raw to one file

### DIFF
--- a/valuation-office/environment.yaml
+++ b/valuation-office/environment.yaml
@@ -1,18 +1,14 @@
 name: valuation-office
 channels:
   - conda-forge
-  - patrikhlobil
 dependencies:
-  - fs-s3fs
+  - odfpy
   - ipykernel
   - ploomber >= 0.12.8
-  - pandas-bokeh
-  - geopandas
-  - seaborn
   - python-dotenv
   - pyarrow
+  - s3fs
 
   - pip
   - pip:
-    - rcbm
-    - git+https://github.com/codema-dev/tasks
+    - codema-dev-tasks==0.1.0

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -63,4 +63,7 @@ tasks:
     product: data/interim/dublin_valuation_office_with_benchmarks.csv
 
   - source: tasks.link_valuation_office_to_small_areas
+    product: data/interim/dublin_valuation_office_with_small_areas.csv
+
+  - source: tasks.remove_none_and_unknown_benchmark_buildings
     product: data/processed/dublin_valuation_office.csv

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -26,6 +26,41 @@ tasks:
       url: s3://codema-dev/raw/2021_06_15_valuation_office_floor_areas_sdcc.ods
     product: data/external/2021_06_15_valuation_office_floor_areas_sdcc.ods
 
+  - source: codema_dev_tasks.requests.fetch_file
+    name: download_benchmarks
+    params:
+      url: https://codema-dev.s3.eu-west-1.amazonaws.com/views/2021_09_24_commercial_floor_area_energy_benchmarks.csv
+    product: data/external/2021_09_24_commercial_floor_area_energy_benchmarks.csv
+    
+  - source: codema_dev_tasks.requests.fetch_file
+    name: download_benchmark_uses
+    params:
+      url: https://codema-dev.s3.eu-west-1.amazonaws.com/views/2021_09_24_commercial_floor_area_energy_benchmarks_linked_to_valuation_office_uses.zip
+    product: data/external/2021_09_24_commercial_floor_area_energy_benchmarks_linked_to_valuation_office_uses.zip
+    
+  - source: codema_dev_tasks.requests.fetch_file
+    name: download_small_area_boundaries
+    params:
+      url: https://codema-dev.s3.eu-west-1.amazonaws.com/views/2021_08_12_dublin_small_area_boundaries.gpkg
+    product: data/external/2021_08_12_dublin_small_area_boundaries.gpkg
+
   - source: tasks.concatenate_local_authority_floor_areas
     product: data/interim/raw_dublin_valuation_office_floor_areas.csv
     on_finish: tasks.validate_dublin_floor_areas
+
+  - source: tasks.convert_benchmark_uses_to_json
+    product: data/interim/benchmark_uses.json
+
+  - source: tasks.weather_adjust_benchmarks
+    product: data/interim/weather_adjusted_benchmarks.csv
+
+  - source: tasks.save_unknown_benchmark_uses
+    product: data/processed/unknown_benchmark_uses.csv
+
+  - source: tasks.apply_energy_benchmarks_to_floor_areas
+    params:
+      boiler_efficiency: 0.85
+    product: data/interim/dublin_valuation_office_with_benchmarks.csv
+
+  - source: tasks.link_valuation_office_to_boundaries
+    product: data/processed/dublin_valuation_office.csv

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -62,5 +62,5 @@ tasks:
       boiler_efficiency: 0.85
     product: data/interim/dublin_valuation_office_with_benchmarks.csv
 
-  - source: tasks.link_valuation_office_to_boundaries
+  - source: tasks.link_valuation_office_to_small_areas
     product: data/processed/dublin_valuation_office.csv

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -25,4 +25,6 @@ tasks:
     params:
       url: s3://codema-dev/raw/2021_06_15_valuation_office_floor_areas_sdcc.ods
     product: data/external/2021_06_15_valuation_office_floor_areas_sdcc.ods
-    
+
+  - source: tasks.concatenate_local_authority_floor_areas
+    product: data/interim/raw_dublin_valuation_office_floor_areas.csv

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -3,111 +3,26 @@ on_render:
   dotenv_path: ".env"
 tasks:
   - source: codema_dev_tasks.requests.fetch_file
-    name: download_buildings
+    name: download_valuation_office_floor_areas_dcc
     params:
-      url: s3://codema-dev/2021_04_dublin_valuation_office.csv
-    product: data/external/2021_04_dublin_valuation_office.csv
+      url: s3://codema-dev/raw/2021_06_15_valuation_office_floor_areas_dcc.ods
+    product: data/external/2021_06_15_valuation_office_floor_areas_dcc.ods
+    
   - source: codema_dev_tasks.requests.fetch_file
-    name: download_benchmarks
+    name: download_valuation_office_floor_areas_dlrcc
     params:
-      url: s3://codema-dev/benchmarks.csv
-    product: data/external/benchmarks.csv
+      url: s3://codema-dev/raw/2021_06_15_valuation_office_floor_areas_dlrcc.ods
+    product: data/external/2021_06_15_valuation_office_floor_areas_dlrcc.ods
+
   - source: codema_dev_tasks.requests.fetch_file
-    name: download_benchmark_uses
+    name: download_valuation_office_floor_areas_fcc
     params:
-      url: s3://codema-dev/benchmarks.zip
-    product: data/external/benchmarks.zip
+      url: s3://codema-dev/raw/2021_06_15_valuation_office_floor_areas_fcc.ods
+    product: data/external/2021_06_15_valuation_office_floor_areas_fcc.ods
+
   - source: codema_dev_tasks.requests.fetch_file
-    name: download_small_area_boundaries
+    name: download_valuation_office_floor_areas_sdcc
     params:
-      url: https://codema-dev.s3.eu-west-1.amazonaws.com/dublin_small_area_boundaries_in_routing_keys.gpkg
-    product: data/external/dublin_small_area_boundaries_in_routing_keys.gpkg
-
-  - source: tasks.convert_benchmark_uses_to_json
-    product: data/interim/benchmark_uses.json
-  - source: tasks.weather_adjust_benchmarks
-    product: data/interim/weather_adjusted_benchmarks.csv
-
-  - source: tasks.save_unknown_benchmark_uses
-    product: data/interim/unknown_benchmark_uses.csv
-
-  - source: tasks.apply_energy_benchmarks_to_floor_areas
-    params:
-      boiler_efficiency: 0.85
-    product: data/processed/2021_04_dublin_valuation_office.csv
-
-  - source: tasks.link_valuation_office_to_boundaries
-    product: data/processed/2021_04_dublin_valuation_office_with_boundaries.csv
-  
-  # SAVE
-  - source: tasks.save_building_columns
-    name: save_electricity_demands
-    params:
-      columns: 
-        - typical_electricity_kwh_per_m2y
-        - electricity_demand_mwh_per_y
-      filter_on_column: electricity_demand_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_electricity_demands.csv
-
-  - source: tasks.save_building_columns
-    name: save_fossil_fuel_demands
-    params:
-      columns: 
-        - typical_fossil_fuel_kwh_per_m2y
-        - fossil_fuel_demand_mwh_per_y
-      filter_on_column: fossil_fuel_demand_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_fossil_fuel_demands.csv
-
-  - source: tasks.save_building_columns
-    name: save_building_energy_demands
-    params:
-      columns: 
-        - typical_building_energy_kwh_per_m2y
-        - building_energy_mwh_per_y
-      filter_on_column: building_energy_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_building_energy_demands.csv
-
-  - source: tasks.save_building_columns
-    name: save_process_energy_demands
-    params:
-      columns: 
-        - typical_process_energy_kwh_per_m2y
-        - process_energy_mwh_per_y
-      filter_on_column: process_energy_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_process_energy_demands.csv
-  
-  - source: tasks.save_building_columns
-    name: save_electricity_heat_demands
-    params:
-      columns: 
-        - typical_electricity_heat_kwh_per_m2y
-        - electricity_heat_demand_mwh_per_y
-      filter_on_column: electricity_heat_demand_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_electricity_heat_demands.csv
-
-  - source: tasks.save_building_columns
-    name: save_fossil_fuel_heat_demands
-    params:
-      columns: 
-        - typical_fossil_fuel_heat_kwh_per_m2y
-        - fossil_fuel_heat_demand_mwh_per_y
-      filter_on_column: fossil_fuel_heat_demand_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_fossil_fuel_heat_demands.csv
-
-  - source: tasks.save_building_columns
-    name: save_industrial_low_temperature_heat_demands
-    params:
-      columns: 
-        - typical_industrial_low_temperature_heat_kwh_per_m2y
-        - industrial_low_temperature_heat_demand_mwh_per_y
-      filter_on_column: industrial_low_temperature_heat_demand_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_industrial_low_temperature_heat_demands.csv
-  
-  - source: tasks.save_building_columns
-    name: save_industrial_high_temperature_heat_demands
-    params:
-      columns: 
-        - typical_industrial_high_temperature_heat_kwh_per_m2y
-        - industrial_high_temperature_heat_demand_mwh_per_y
-      filter_on_column: industrial_high_temperature_heat_demand_mwh_per_y
-    product: data/processed/2021_04_dublin_valuation_office_industrial_high_temperature_heat_demands.csv
+      url: s3://codema-dev/raw/2021_06_15_valuation_office_floor_areas_sdcc.ods
+    product: data/external/2021_06_15_valuation_office_floor_areas_sdcc.ods
+    

--- a/valuation-office/pipeline.yaml
+++ b/valuation-office/pipeline.yaml
@@ -28,3 +28,4 @@ tasks:
 
   - source: tasks.concatenate_local_authority_floor_areas
     product: data/interim/raw_dublin_valuation_office_floor_areas.csv
+    on_finish: tasks.validate_dublin_floor_areas

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -222,14 +222,14 @@ def weather_adjust_benchmarks(upstream: Any, product: Any) -> None:
         }
     )
 
-    normalised_benchmarks.to_csv(product)
+    normalised_benchmarks.to_csv(product, index=False)
 
 
 def replace_unexpectedly_large_floor_areas_with_typical_values(
     upstream: Any, product: Any
 ) -> None:
-    buildings = pd.read_csv(upstream["download_buildings"])
-    benchmarks = pd.read_csv(upstream["weather_adjust_benchmarks"], index_col=0)
+    buildings = pd.read_csv(upstream["concatenate_local_authority_floor_areas"])
+    benchmarks = pd.read_csv(upstream["weather_adjust_benchmarks"])
     with open(upstream["convert_benchmark_uses_to_json"], "r") as f:
         benchmark_uses = json.load(f)
 
@@ -264,8 +264,8 @@ def replace_unexpectedly_large_floor_areas_with_typical_values(
 
 
 def save_unknown_benchmark_uses(upstream: Any, product: Any) -> None:
-    buildings = pd.read_csv(upstream["download_buildings"])
-    benchmarks = pd.read_csv(upstream["weather_adjust_benchmarks"], index_col=0)
+    buildings = pd.read_csv(upstream["concatenate_local_authority_floor_areas"])
+    benchmarks = pd.read_csv(upstream["weather_adjust_benchmarks"])
     with open(upstream["convert_benchmark_uses_to_json"], "r") as f:
         benchmark_uses = json.load(f)
 
@@ -287,7 +287,7 @@ def apply_energy_benchmarks_to_floor_areas(
 ) -> None:
 
     buildings = pd.read_csv(upstream["concatenate_local_authority_floor_areas"])
-    benchmarks = pd.read_csv(upstream["weather_adjust_benchmarks"], index_col=0)
+    benchmarks = pd.read_csv(upstream["weather_adjust_benchmarks"])
     with open(upstream["convert_benchmark_uses_to_json"], "r") as f:
         benchmark_uses = json.load(f)
 
@@ -366,7 +366,7 @@ def apply_energy_benchmarks_to_floor_areas(
         * kwh_to_mwh
     )
 
-    buildings_with_benchmarks.to_csv(product)
+    buildings_with_benchmarks.to_csv(product, index=False)
 
 
 def link_valuation_office_to_boundaries(upstream: Any, product: Any) -> None:
@@ -386,7 +386,7 @@ def link_valuation_office_to_boundaries(upstream: Any, product: Any) -> None:
         small_area_boundaries,
         op="within",
     ).drop(columns="geometry")
-    valuation_office_in_small_areas.to_csv(product)
+    valuation_office_in_small_areas.to_csv(product, index=False)
 
 
 def save_building_columns(
@@ -412,8 +412,8 @@ def save_building_columns(
         "RoutingKey",
     ]
     use_columns = attribute_columns + columns + boundary_columns
-    buildings = pd.read_csv(
-        upstream["link_valuation_office_to_boundaries"], index_col=0
-    ).loc[:, use_columns]
+    buildings = pd.read_csv(upstream["link_valuation_office_to_boundaries"]).loc[
+        :, use_columns
+    ]
     non_zero_rows = buildings[filter_on_column] > 0
     buildings[non_zero_rows].to_csv(product, index=False)

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -7,6 +7,15 @@ import geopandas as gpd
 import pandas as pd
 
 
+def concatenate_local_authority_floor_areas(upstream: Any, product: Any) -> None:
+    dcc = pd.read_excel(upstream["download_valuation_office_floor_areas_dcc"])
+    dlrcc = pd.read_excel(upstream["download_valuation_office_floor_areas_dlrcc"])
+    sdcc = pd.read_excel(upstream["download_valuation_office_floor_areas_sdcc"])
+    fcc = pd.read_excel(upstream["download_valuation_office_floor_areas_fcc"])
+    dublin = pd.concat([dcc, dlrcc, sdcc, fcc])
+    dublin.to_csv(product)
+
+
 def convert_benchmark_uses_to_json(upstream: Any, product: Any) -> None:
     uses_grouped_by_category = defaultdict()
     with ZipFile(upstream["download_benchmark_uses"]) as zf:

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -387,3 +387,11 @@ def link_valuation_office_to_small_areas(upstream: Any, product: Any) -> None:
         op="within",
     ).drop(columns=["geometry", "index_right"])
     valuation_office_in_small_areas.to_csv(product, index=False)
+
+
+def remove_none_and_unknown_benchmark_buildings(upstream: Any, product: Any) -> None:
+    buildings = pd.read_csv(upstream["link_valuation_office_to_small_areas"])
+    without_none_or_unknown_benchmarks = buildings.query(
+        "Benchmark != ['Unknown', 'None']"
+    )
+    without_none_or_unknown_benchmarks.to_csv(product)

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -369,7 +369,7 @@ def apply_energy_benchmarks_to_floor_areas(
     buildings_with_benchmarks.to_csv(product, index=False)
 
 
-def link_valuation_office_to_boundaries(upstream: Any, product: Any) -> None:
+def link_valuation_office_to_small_areas(upstream: Any, product: Any) -> None:
     valuation_office = pd.read_csv(upstream["apply_energy_benchmarks_to_floor_areas"])
     small_area_boundaries = gpd.read_file(
         str(upstream["download_small_area_boundaries"])
@@ -383,7 +383,7 @@ def link_valuation_office_to_boundaries(upstream: Any, product: Any) -> None:
     )
     valuation_office_in_small_areas = gpd.sjoin(
         valuation_office_geo,
-        small_area_boundaries,
+        small_area_boundaries[["small_area", "geometry"]],
         op="within",
-    ).drop(columns="geometry")
+    ).drop(columns=["geometry", "index_right"])
     valuation_office_in_small_areas.to_csv(product, index=False)

--- a/valuation-office/tasks.py
+++ b/valuation-office/tasks.py
@@ -387,33 +387,3 @@ def link_valuation_office_to_boundaries(upstream: Any, product: Any) -> None:
         op="within",
     ).drop(columns="geometry")
     valuation_office_in_small_areas.to_csv(product, index=False)
-
-
-def save_building_columns(
-    upstream: Any, product: Any, columns: str, filter_on_column: str
-) -> None:
-    attribute_columns = [
-        "PropertyNo",
-        "Category",
-        "Use1",
-        "Use2",
-        "List_Status",
-        "Benchmark",
-        "Total_SQM",
-        "bounded_area_m2",
-    ]
-    boundary_columns = [
-        "X_ITM",
-        "Y_ITM",
-        "small_area",
-        "cso_ed_id",
-        "countyname",
-        "local_authority",
-        "RoutingKey",
-    ]
-    use_columns = attribute_columns + columns + boundary_columns
-    buildings = pd.read_csv(upstream["link_valuation_office_to_boundaries"]).loc[
-        :, use_columns
-    ]
-    non_zero_rows = buildings[filter_on_column] > 0
-    buildings[non_zero_rows].to_csv(product, index=False)


### PR DESCRIPTION
Instead of reading valuation office data from a view (i.e. a dataset built itself from raw data, in this case by concatenating the 4 Dublin local authority `ods` files into a single `csv` of floor areas) read it from raw.  This will enable easier adaptation of the valuation-office project to future requests of data